### PR TITLE
feat: drop support for php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "symfony/framework-bundle": "^6.4 || ^7.0",
         "ivory/google-map": "v6.x-dev"
     },


### PR DESCRIPTION
The minimum supported for symfony 6.4 is PHP 8.1.