### PR TITLE
chore: migrate phpunit config-files to PHPUnit 9

### DIFF
--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit colors="true" bootstrap="Tests/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         bootstrap="Tests/autoload.php"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+>
     <testsuites>
         <testsuite name="IvoryGoogleMapBundle Test Suite">
-            <directory suffix="Test.php">./Tests</directory>
+            <directory>./Tests</directory>
         </testsuite>
     </testsuites>
+
     <php>
         <server name="BROWSER_NAME" value="chrome" />
         <server name="SELENIUM_HOST" value="selenium-chrome" />
@@ -14,20 +18,23 @@
         <server name="API_KEY" value="" />
         <server name="API_SECRET" value="" />
     </php>
-    <filter>
-        <whitelist>
+
+    <coverage>
+        <include>
             <directory>./</directory>
-            <exclude>
-                <directory>./Resources</directory>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
+
     <groups>
         <exclude>
             <!-- Temporarily disabled due to incorrect batch execution errors -->
             <group>functional</group>
         </exclude>
     </groups>
+
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         bootstrap="Tests/autoload.php"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+>
+  <testsuites>
+    <testsuite name="IvoryGoogleMapBundle Test Suite">
+      <directory>./Tests</directory>
+    </testsuite>
+  </testsuites>
 
-<phpunit colors="true" bootstrap="Tests/autoload.php">
-    <testsuites>
-        <testsuite name="IvoryGoogleMapBundle Test Suite">
-            <directory suffix="Test.php">./Tests</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <server name="API_KEY" value="AIzaSyAbfXoOk_L4Ryk6aFvdqeAJvbg1ShYiqAE" />
-        <server name="API_SECRET" value="78BBhyDNOeFG_PWqHi6XUJ3woJE=" />
-        <server name="BROWSER_NAME" value="chrome" />
-        <server name="SELENIUM_HOST" value="selenium-chrome" />
-        <server name="CACHE_PATH" value="Tests/.cache" />
-        <server name="CACHE_RESET" value="false" />
-    </php>
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Resources</directory>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <groups>
-        <exclude>
-            <group>functional</group>
-        </exclude>
-    </groups>
+  <php>
+    <server name="API_KEY" value="AIzaSyAbfXoOk_L4Ryk6aFvdqeAJvbg1ShYiqAE"/>
+    <server name="API_SECRET" value="78BBhyDNOeFG_PWqHi6XUJ3woJE="/>
+    <server name="BROWSER_NAME" value="chrome"/>
+    <server name="SELENIUM_HOST" value="selenium-chrome"/>
+    <server name="CACHE_PATH" value="Tests/.cache"/>
+    <server name="CACHE_RESET" value="false"/>
+  </php>
+
+  <coverage>
+      <include>
+          <directory>./</directory>
+      </include>
+      <exclude>
+          <directory>./Resources</directory>
+          <directory>./Tests</directory>
+          <directory>./vendor</directory>
+      </exclude>
+  </coverage>
+
+  <groups>
+    <exclude>
+      <group>functional</group>
+    </exclude>
+  </groups>
+
 </phpunit>


### PR DESCRIPTION
`suffix="Test.php"` is the default and the reason i deleted it.